### PR TITLE
bug: return 0 from main

### DIFF
--- a/bash-tpl
+++ b/bash-tpl
@@ -1289,6 +1289,8 @@ function main() {
 	fi
 
 	process_stdin
+
+	return 0 # ALL OK
 }
 
 # Only process main logic if not being sourced (ie tested)

--- a/test/tpl.bats.sh
+++ b/test/tpl.bats.sh
@@ -17,6 +17,7 @@ printf "%s\n" \#
 printf "%s\n" test_template\(\)\ \{
 printf "%s\n" $'\tpushd "${BATS_TEST_DIRNAME}" >> /dev/null'
 printf "%s\n" $'\trun main "${BATS_TEST_DIRNAME}/${1}"'
+printf "%s\n" $'\t[[ $status = 0 ]]'
 printf "%s\n" $'\tdiff_output_file "${BATS_TEST_DIRNAME}/${1%.tpl}.sh"'
 printf "%s\n" $'\tpopd >> /dev/null'
 printf "%s\n" \}

--- a/test/tpl.bats.tpl
+++ b/test/tpl.bats.tpl
@@ -19,6 +19,7 @@ setup() {
 test_template() {
 	pushd "${BATS_TEST_DIRNAME}" >> /dev/null
 	run main "${BATS_TEST_DIRNAME}/${1}"
+	[[ $status = 0 ]]
 	diff_output_file "${BATS_TEST_DIRNAME}/${1%.tpl}.sh"
 	popd >> /dev/null
 }


### PR DESCRIPTION
Ensures script exits with code `0` on success.